### PR TITLE
Meta Queries V2:  Implement ordering by multiple meta values

### DIFF
--- a/src/Data/Config.php
+++ b/src/Data/Config.php
@@ -86,13 +86,8 @@ class Config {
 			 * Ensure the cursor_offset is a positive integer
 			 */
 			if ( is_integer( $cursor_offset ) && 0 < $cursor_offset ) {
-
 				$post_cursor = new PostObjectCursor( $cursor_offset, $query );
-				$custom = $post_cursor->get_where();
-				error_log("\n\nWHERE $custom ENDWERE\n");
-
-				$where .= $custom;
-
+				$where .= $post_cursor->get_where();
 			}
 		}
 

--- a/src/Data/Config.php
+++ b/src/Data/Config.php
@@ -88,7 +88,10 @@ class Config {
 			if ( is_integer( $cursor_offset ) && 0 < $cursor_offset ) {
 
 				$post_cursor = new PostObjectCursor( $cursor_offset, $query );
-				$where .= $post_cursor->get_where();
+				$custom = $post_cursor->get_where();
+				error_log("\n\nWHERE $custom ENDWERE\n");
+
+				$where .= $custom;
 
 			}
 		}

--- a/src/Data/CursorBuilder.php
+++ b/src/Data/CursorBuilder.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace WPGraphQL\Data;
+
+// error_reporting(E_ALL);
+// ini_set('display_errors', 1);
+
+class CursorBuilder {
+
+	public $fields;
+
+	public $compare = null;
+
+	public function __construct( $compare = '>') {
+		$this->compare = $compare;
+		$this->fields = [];
+	}
+
+	public function add_field( $key, $value, $type = null, $order = null ) {
+		$this->fields[] = [
+			'key' => $key,
+			'value' => $value,
+			'type' => $type,
+			'order' => $order,
+		];
+	}
+
+	public function has_fields() {
+		return count( $this->fields ) > 0;
+	}
+
+	public function to_sql( $fields = null ) {
+		if ( null === $fields ) {
+			$fields = $this->fields;
+		}
+
+		if ( count( $fields ) === 0 ) {
+			return '';
+		}
+
+		$field = $fields[0];
+
+		$key = $field['key'];
+		$value = $field['value'];
+		$type = $field['type'];
+		$order = $field['order'];
+
+		$compare = $this->compare;
+
+		if ( null !== $order ) {
+			error_log("\n\nUSing custom order\n\n");
+			$compare = 'DESC' === $order ? '<' : '>';
+		}
+
+
+		if ( 'ID' !== $type ) {
+			$cast = $this->get_cast_for_type( $type );
+			if ( 'CHAR' === $cast ) {
+				$value = "'$value'";
+			} else if ( $cast ) {
+				$key = "CAST( '$key' as $cast )";
+				$value = "CAST( '$value' as $cast )";
+			}
+		}
+
+		if ( count( $fields ) === 1 ) {
+			return " {$key} {$compare} {$value}";
+		}
+
+		$nest = $this->to_sql( \array_slice( $fields, 1 ) );
+		return " {$key} {$compare}= {$value} AND ( {$key} {$compare} {$value} OR ( {$nest} ) ) ";
+	}
+
+
+	/**
+	 * Copied from https://github.com/WordPress/WordPress/blob/c4f8bc468db56baa2a3bf917c99cdfd17c3391ce/wp-includes/class-wp-meta-query.php#L272-L296
+	 *
+	 * It's an intance method. No way to call it without creating the instance?
+	 *
+	 * Return the appropriate alias for the given meta type if applicable.
+	 *
+	 * @param string $type MySQL type to cast meta_value.
+	 * @return string MySQL type.
+	 */
+	public function get_cast_for_type( $type = '' ) {
+		if ( empty( $type ) ) {
+			return 'CHAR';
+		}
+		$meta_type = strtoupper( $type );
+		if ( ! preg_match( '/^(?:BINARY|CHAR|DATE|DATETIME|SIGNED|UNSIGNED|TIME|NUMERIC(?:\(\d+(?:,\s?\d+)?\))?|DECIMAL(?:\(\d+(?:,\s?\d+)?\))?)$/', $meta_type ) ) {
+			return 'CHAR';
+		}
+		if ( 'NUMERIC' == $meta_type ) {
+			$meta_type = 'SIGNED';
+		}
+		return $meta_type;
+	}
+}
+
+
+// $ding = new CursorBuilder();
+// $ding->add_field('c1', ':lrv1');
+// $ding->add_field('c2', ':lrv2');
+// $ding->add_field('c3', ':lrv3', 'NUMERIC');
+
+// error_log("select * from " . $ding->to_sql());

--- a/src/Data/CursorBuilder.php
+++ b/src/Data/CursorBuilder.php
@@ -58,7 +58,7 @@ class CursorBuilder {
 			if ( 'CHAR' === $cast ) {
 				$value = "'$value'";
 			} else if ( $cast ) {
-				$key = "CAST( '$key' as $cast )";
+				$key = "CAST( $key as $cast )";
 				$value = "CAST( '$value' as $cast )";
 			}
 		}

--- a/src/Data/CursorBuilder.php
+++ b/src/Data/CursorBuilder.php
@@ -33,11 +33,15 @@ class CursorBuilder {
 	 * @param string    $order custom order
 	 */
 	public function add_field( $key, $value, $type = null, $order = null ) {
+		/**
+		 * This only input for variables which are used in the SQL generation. So
+		 * escape them here.
+		 */
 		$this->fields[] = [
-			'key' => $key,
-			'value' => $value,
-			'type' => $type,
-			'order' => $order,
+			'key' => esc_sql( $key ),
+			'value' => esc_sql( $value ),
+			'type' => esc_sql( $type ),
+			'order' => esc_sql( $order ),
 		];
 	}
 

--- a/src/Data/CursorBuilder.php
+++ b/src/Data/CursorBuilder.php
@@ -2,13 +2,19 @@
 
 namespace WPGraphQL\Data;
 
-// error_reporting(E_ALL);
-// ini_set('display_errors', 1);
-
+/**
+ * Generic class for building AND&OR operators for cursor based paginators
+ */
 class CursorBuilder {
 
+	/**
+	 * The field by which the cursor should order the results
+	 */
 	public $fields;
 
+	/**
+	 * Default comparison operator. < or >
+	 */
 	public $compare = null;
 
 	public function __construct( $compare = '>') {
@@ -16,6 +22,16 @@ class CursorBuilder {
 		$this->fields = [];
 	}
 
+	/**
+	* Add ordering field. The order you call this method matters. First field
+	* will be the primary field and latters ones will be used if the primary
+	* field has duplicate values
+	 *
+	 * @param string    $key database colum
+	 * @param string    $value value from the current cursor
+	 * @param string    $type type cast
+	 * @param string    $order custom order
+	 */
 	public function add_field( $key, $value, $type = null, $order = null ) {
 		$this->fields[] = [
 			'key' => $key,
@@ -25,10 +41,20 @@ class CursorBuilder {
 		];
 	}
 
+	/**
+	 * Returns true at least one ordering field has been added
+	 *
+	 * @return boolean
+	 */
 	public function has_fields() {
 		return count( $this->fields ) > 0;
 	}
 
+	/**
+	 * Generate the final SQL string to be appended to WHERE claise
+	 *
+	 * @return string
+	 */
 	public function to_sql( $fields = null ) {
 		if ( null === $fields ) {
 			$fields = $this->fields;
@@ -48,7 +74,6 @@ class CursorBuilder {
 		$compare = $this->compare;
 
 		if ( null !== $order ) {
-			error_log("\n\nUSing custom order\n\n");
 			$compare = 'DESC' === $order ? '<' : '>';
 		}
 
@@ -96,11 +121,3 @@ class CursorBuilder {
 		return $meta_type;
 	}
 }
-
-
-// $ding = new CursorBuilder();
-// $ding->add_field('c1', ':lrv1');
-// $ding->add_field('c2', ':lrv2');
-// $ding->add_field('c3', ':lrv3', 'NUMERIC');
-
-// error_log("select * from " . $ding->to_sql());

--- a/src/Data/PostObjectConnectionResolver.php
+++ b/src/Data/PostObjectConnectionResolver.php
@@ -223,6 +223,7 @@ class PostObjectConnectionResolver extends ConnectionResolver {
 	 */
 	public static function get_query( $query_args ) {
 		$query = new \WP_Query( $query_args );
+		\error_log( \print_r( $query->request, true ) );
 
 		return $query;
 	}

--- a/src/Data/PostObjectConnectionResolver.php
+++ b/src/Data/PostObjectConnectionResolver.php
@@ -223,7 +223,6 @@ class PostObjectConnectionResolver extends ConnectionResolver {
 	 */
 	public static function get_query( $query_args ) {
 		$query = new \WP_Query( $query_args );
-		\error_log( \print_r( $query->request, true ) );
 
 		return $query;
 	}

--- a/src/Data/PostObjectCursor.php
+++ b/src/Data/PostObjectCursor.php
@@ -44,6 +44,7 @@ class PostObjectCursor {
 	 */
 	public $builder;
 
+	public $meta_join_alias = 0;
 
 	/**
 	 * PostCursor constructor.
@@ -162,7 +163,19 @@ class PostObjectCursor {
 		$meta_type = ! empty( $this->query->query_vars["meta_type"] ) ? esc_sql( $this->query->query_vars["meta_type"] ) : null;
 		$meta_value = esc_sql( get_post_meta( $this->cursor_offset, $meta_key, true ) );
 
-		$this->builder->add_field( "{$this->wpdb->postmeta}.meta_value", $meta_value, $meta_type, $order );
+		$key = "{$this->wpdb->postmeta}.meta_value";
+
+		/**
+		 * wp uses mt1, mt2 etc. style aliases for additional meta value joins.
+		 */
+		if ( $this->meta_join_alias !== 0 ) {
+			$key = "mt{$this->meta_join_alias}.meta_value";
+
+		}
+
+		$this->meta_join_alias++;
+
+		$this->builder->add_field($key , $meta_value, $meta_type, $order );
 	}
 
 	/**

--- a/src/Data/PostObjectCursor.php
+++ b/src/Data/PostObjectCursor.php
@@ -204,28 +204,4 @@ class PostObjectCursor {
 		return empty( $clause['key'] ) ? null : $clause['key'];
 	}
 
-	/**
-	 * Copied from https://github.com/WordPress/WordPress/blob/c4f8bc468db56baa2a3bf917c99cdfd17c3391ce/wp-includes/class-wp-meta-query.php#L272-L296
-	 *
-	 * It's an intance method. No way to call it without creating the instance?
-	 *
-	 * Return the appropriate alias for the given meta type if applicable.
-	 *
-	 * @param string $type MySQL type to cast meta_value.
-	 * @return string MySQL type.
-	 */
-	public function get_cast_for_type( $type = '' ) {
-		if ( empty( $type ) ) {
-			return 'CHAR';
-		}
-		$meta_type = strtoupper( $type );
-		if ( ! preg_match( '/^(?:BINARY|CHAR|DATE|DATETIME|SIGNED|UNSIGNED|TIME|NUMERIC(?:\(\d+(?:,\s?\d+)?\))?|DECIMAL(?:\(\d+(?:,\s?\d+)?\))?)$/', $meta_type ) ) {
-			return 'CHAR';
-		}
-		if ( 'NUMERIC' == $meta_type ) {
-			$meta_type = 'SIGNED';
-		}
-		return $meta_type;
-	}
-
 }

--- a/src/Data/PostObjectCursor.php
+++ b/src/Data/PostObjectCursor.php
@@ -160,8 +160,8 @@ class PostObjectCursor {
 	 * @return string
 	 */
 	private function compare_with_meta_field( $meta_key, $order ) {
-		$meta_type = ! empty( $this->query->query_vars["meta_type"] ) ? esc_sql( $this->query->query_vars["meta_type"] ) : null;
-		$meta_value = esc_sql( get_post_meta( $this->cursor_offset, $meta_key, true ) );
+		$meta_type = ! empty( $this->query->query_vars["meta_type"] ) ? $this->query->query_vars["meta_type"] : null;
+		$meta_value = get_post_meta( $this->cursor_offset, $meta_key, true );
 
 		$key = "{$this->wpdb->postmeta}.meta_value";
 
@@ -188,7 +188,7 @@ class PostObjectCursor {
 	private function get_meta_key( $by ) {
 
 		if ( 'meta_value' === $by ) {
-			return ! empty( $this->query->query_vars["meta_key"] ) ? esc_sql( $this->query->query_vars["meta_key"] ) : null;
+			return ! empty( $this->query->query_vars["meta_key"] ) ? $this->query->query_vars["meta_key"] : null;
 		}
 
 		/**

--- a/src/Data/PostObjectCursor.php
+++ b/src/Data/PostObjectCursor.php
@@ -144,7 +144,7 @@ class PostObjectCursor {
 		 */
 		$meta_key = $this->get_meta_key( $by );
 		if ( $meta_key ) {
-			$this->compare_with_meta_field( $meta_key );
+			$this->compare_with_meta_field( $meta_key, $order );
 			return;
 		}
 
@@ -158,11 +158,11 @@ class PostObjectCursor {
 	 *
 	 * @return string
 	 */
-	private function compare_with_meta_field( $meta_key ) {
+	private function compare_with_meta_field( $meta_key, $order ) {
 		$meta_type = ! empty( $this->query->query_vars["meta_type"] ) ? esc_sql( $this->query->query_vars["meta_type"] ) : null;
 		$meta_value = esc_sql( get_post_meta( $this->cursor_offset, $meta_key, true ) );
 
-		$this->builder->add_field( "{$this->wpdb->postmeta}.meta_value", $meta_value, $meta_type );
+		$this->builder->add_field( "{$this->wpdb->postmeta}.meta_value", $meta_value, $meta_type, $order );
 	}
 
 	/**

--- a/tests/wpunit/PostObjectCursorTest.php
+++ b/tests/wpunit/PostObjectCursorTest.php
@@ -434,4 +434,32 @@ class PostObjectCursorTest extends \Codeception\TestCase\WPTestCase {
 			'meta_key' => 'test_meta',
 		] );
 	}
+
+	public function testPostOrderingByMultipleQueryClause() {
+		foreach ($this->created_post_ids as $index => $post_id) {
+			update_post_meta($post_id, 'test_meta1', $this->formatNumber( 10 ) );
+		}
+		foreach ($this->created_post_ids as $index => $post_id) {
+			update_post_meta($post_id, 'test_meta2', $this->formatNumber( $index ) );
+		}
+		// Move number 19 to the second page when ordering by test_meta
+		$this->deleteByMetaKey( 'test_meta2', $this->formatNumber( 7 ) );
+		update_post_meta($this->created_post_ids[19], 'test_meta2', $this->formatNumber( 7 ) );
+		$this->assertQueryInCursor( [
+			'orderby' => [
+				'test_clause1' => 'ASC',
+				'test_clause2' => 'ASC',
+			],
+			'meta_query' => [
+				'test_clause1' => [
+					'key' => 'test_meta1',
+					'compare' => 'EXISTS',
+				],
+				'test_clause2' => [
+					'key' => 'test_meta2',
+					'compare' => 'EXISTS',
+				]
+			]
+		] );
+	}
 }

--- a/tests/wpunit/PostObjectCursorTest.php
+++ b/tests/wpunit/PostObjectCursorTest.php
@@ -165,7 +165,6 @@ class PostObjectCursorTest extends \Codeception\TestCase\WPTestCase {
 		] ) );
 
 		$expected = wp_list_pluck($q->posts, 'post_title');
-		// error_log(print_r($expected, true));
 
 		// Aserting like this we get more readable assertion fail message
 		$this->assertEquals( implode(',', $expected), implode(',', $actual) );

--- a/tests/wpunit/PostObjectCursorTest.php
+++ b/tests/wpunit/PostObjectCursorTest.php
@@ -200,7 +200,7 @@ class PostObjectCursorTest extends \Codeception\TestCase\WPTestCase {
 		] );
 	}
 
-	public function testPostOrderingByMetaString() {
+	public function testPostOrderingByMetaStringASC() {
 
 		// Add post meta to created posts
 		foreach ($this->created_post_ids as $index => $post_id) {
@@ -213,6 +213,24 @@ class PostObjectCursorTest extends \Codeception\TestCase\WPTestCase {
 
 		$this->assertQueryInCursor( [
 			'orderby' => [ 'meta_value' => 'ASC', ],
+			'meta_key' => 'test_meta',
+		] );
+
+	}
+
+	public function testPostOrderingByMetaStringDESC() {
+
+		// Add post meta to created posts
+		foreach ($this->created_post_ids as $index => $post_id) {
+			update_post_meta($post_id, 'test_meta', $this->formatNumber( $index ) );
+		}
+
+		// Move number 19 to the second page when ordering by test_meta
+		$this->deleteByMetaKey( 'test_meta', $this->formatNumber( 6 ) );
+		update_post_meta($this->created_post_ids[19], 'test_meta', $this->formatNumber( 6 ) );
+
+		$this->assertQueryInCursor( [
+			'orderby' => [ 'meta_value' => 'DESC', ],
 			'meta_key' => 'test_meta',
 		] );
 
@@ -254,7 +272,7 @@ class PostObjectCursorTest extends \Codeception\TestCase\WPTestCase {
 		] );
 	}
 
-	public function testPostOrderingByMetaNumber() {
+	public function testPostOrderingByMetaNumberASC() {
 
 		// Add post meta to created posts
 		foreach ($this->created_post_ids as $index => $post_id) {


### PR DESCRIPTION
The generated SQL for multi meta value ordering looks like this:

```sql
SELECT wp_posts.ID
FROM wp_posts
INNER JOIN wp_postmeta ON (wp_posts.ID = wp_postmeta.post_id)
INNER JOIN wp_postmeta AS mt1 ON (wp_posts.ID = mt1.post_id)
WHERE 1 = 1
	AND wp_posts.post_parent = 0
	AND wp_posts.post_author IN (2)
	AND (
		wp_postmeta.meta_key = 'test_meta1'
		AND mt1.meta_key = 'test_meta2'
		)
	AND wp_posts.post_type = 'post'
	AND ((wp_posts.post_status = 'publish'))
	AND wp_postmeta.meta_value >= '00000010'
	AND (
		wp_postmeta.meta_value > '00000010'
		OR (mt1.meta_value > '00000005')
		)
GROUP BY wp_posts.ID
ORDER BY CAST(wp_postmeta.meta_value AS CHAR) ASC
	,CAST(mt1.meta_value AS CHAR) ASC
	,wp_posts.ID DESC LIMIT 0
	,6
```